### PR TITLE
Added logout method

### DIFF
--- a/fusionsolar/client.py
+++ b/fusionsolar/client.py
@@ -110,6 +110,16 @@ class Client:
             {'XSRF-TOKEN': r.cookies.get(name='XSRF-TOKEN')})
         self.token_expiration_time = pd.Timestamp.utcnow().timestamp() + 1200
 
+    def logout(self):
+        url = f'{self.base_url}/logout'
+        body = {
+            'xsrfToken': self.session.headers['XSRF-TOKEN']
+        }
+        self.session.cookies.clear()
+        r = self.session.post(url=url, json=body)
+        self._validate_response(response=r)
+        self.token_expiration_time = 0
+
     @staticmethod
     def _validate_response(response: requests.Response) -> bool:
         response.raise_for_status()


### PR DESCRIPTION
I've added a logout method that uses the fusionsolar.huawei.com/thirdData/logout endpoint provided in the manual. This is helpful when getting error 403 mentioned in issue https://github.com/EnergieID/FusionSolar/issues/7